### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/components/SSD1306_Driver/CMakeLists.txt
+++ b/components/SSD1306_Driver/CMakeLists.txt
@@ -2,4 +2,7 @@ set(COMPONENT_ADD_INCLUDEDIRS "inc")
 set(COMPONENT_SRCS  "src/fonts.c" 
                     "src/ssd1306.c"
 )
-register_component()
+# Fix cmake build
+idf_component_register(SRCS "${COMPONENT_SRCS}"
+                       PRIV_REQUIRES driver
+                       INCLUDE_DIRS "${COMPONENT_ADD_INCLUDEDIRS}")


### PR DESCRIPTION
The idf.py build was not building correctly has it requires to include the driver when doing custom components. I fixed the bug and made a pull-request.